### PR TITLE
Menciona que a versão do Ansible deve ser de 1.9 pra cima.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 #### Instalando o Vagrant e o Ansible
 
-1. Instale o [Ansible](http://www.ansible.com "ansible")
+1. Instale o [Ansible](http://www.ansible.com "ansible") **a partir da versão 1.9**
 2. Instale o [Vagrant](http://www.vagrantup.com/ "vagrant")
 3. Instale o [VirtualBox](https://www.virtualbox.org/wiki/Downloads "virtualbox")
 


### PR DESCRIPTION
Uma pequena atualização no README.

Eu já tinha o Ansible, só que não conseguia rodar o vagrant up ou o provision pois dava um erro de não reconhecer o become_user do postgres.
Pesquisando vi que era um problema com minha versão do Ansible, que era menor do que 1.9 (recomendável).
Após a atualização tudo funcionou bem :smile: 
