### PR TITLE
Corrige problemas com rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,8 @@
 AllCops:
   RunRailsCops: true
   Exclude:
-    - 'bin/*'
+    - 'bin/**/*'
+    - 'node_modules/**/*'
     - 'db/schema.rb'
     - 'config/initializers/devise.rb'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,13 +2,12 @@ new_plugin_installed = false
 %w(
   vagrant-cachier
 ).each do |plugin|
-  unless Vagrant.has_plugin?(plugin)
-    puts "Missing plugin #{plugin}, installing..."
-    `vagrant plugin install #{plugin}`
-    new_plugin_installed = true
-  end
+  next if Vagrant.has_plugin?(plugin)
+  puts "Missing plugin #{plugin}, installing..."
+  `vagrant plugin install #{plugin}`
+  new_plugin_installed = true
 end
-exec "vagrant #{ARGV.join' '}" if new_plugin_installed
+exec "vagrant #{ARGV.join(' ')}" if new_plugin_installed
 
 BASE_PATH = '/vagrant/transervicos'
 VAGRANTFILE_API_VERSION = '2'


### PR DESCRIPTION
Ignora arquivos dentro de `node_modules` no `.rubocop.yml` e corrige problema no `Vagrantfile`.
