### PR TITLE
Configura karma pra rodar no snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "grunt-cli": "^0.1.13",
     "grunt-karma": "^0.12.1",
     "jasmine-core": "^2.4.1",
-    "karma": "^0.13.19",
+    "karma": "^0.13.21",
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.3"

--- a/spec/karma/config/karma.conf.js
+++ b/spec/karma/config/karma.conf.js
@@ -17,12 +17,11 @@ module.exports = function(config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: true,
     plugins : [
       'karma-phantomjs-launcher',
       'karma-jasmine'
     ],
     browsers: ['PhantomJS'],
-    singleRun: false
+    singleRun: true
   })
 };


### PR DESCRIPTION
Temos uma instrução no README pra rodar os testes do grunt, mas ele não está no nosso pipeline no snap.
No código é preciso alterar as configurações do karma pra evitar que ele fique rodando infinitamente. Essas foram as alterações feitas aqui.
