### PR TITLE
Adiciona health check para aplicação

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'rails_admin'
 
 gem 'friendly_id', '~> 5.0.1'
 
+gem 'health-monitor-rails'
+
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.7)
       tilt
+    health-monitor-rails (4.1.0)
+      rails (>= 3.2)
     i18n (0.7.0)
     jasmine (2.4.0)
       jasmine-core (~> 2.4)
@@ -280,6 +282,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   friendly_id (~> 5.0.1)
+  health-monitor-rails
   jasmine
   jasny-bootstrap-rails
   jbuilder (~> 2.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,32 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+require 'net/https'
+require 'uri'
+require 'json'
 
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+namespace :smoketest do
+  task :development do
+    uri = URI.parse('http://localhost:8080/check')
+    check(uri)
+  end
+
+  task :production do
+    uri = URI.parse('http://transervicos.herokuapp.com/check')
+    check(uri)
+  end
+end
+
+def check(uri)
+  http = Net::HTTP.new(uri.host, uri.port)
+
+  request = Net::HTTP::Get.new(uri.request_uri)
+  res = http.request(request)
+
+  fail "Application is not ok! Status: #{res.code}" if res.code != '200'
+  puts "Application is ok! Status: #{res.code}"
+  puts JSON.parse(res.body)
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,7 @@ module Transervicos
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.version = '1.0.0'
   end
 end

--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -1,0 +1,8 @@
+HealthMonitor.configure do |config|
+  config.database
+
+  config.environmet_variables = {
+    version: Rails.configuration.version,
+    migration_version: ActiveRecord::Migrator.current_version
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+  mount HealthMonitor::Engine, at: '/'
+
   scope(path_names: { new: 'novo', edit: 'editar' }) do
     resources :services, path: 'servicos'
   end


### PR DESCRIPTION
Podemos agora checar a página `/check` para saber se a aplicação está de pé, versão atual etc. Assim podemos adicionar um passo pós-implantação que execute smoke tests, usando a task `smoketest:production`.

Essa é uma configuração inicial que pode ser melhorada conforme novos serviços forem adicionados.
