### PR TITLE
Adiciona versionamento e tasks para subir e diminuir a versão

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,5 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
-require 'net/https'
-require 'uri'
-require 'json'
 require 'rubocop/rake_task'
 
 require File.expand_path('../config/application', __FILE__)
@@ -10,26 +7,3 @@ require File.expand_path('../config/application', __FILE__)
 Rails.application.load_tasks
 
 RuboCop::RakeTask.new
-
-namespace :smoketest do
-  task :development do
-    uri = URI.parse('http://localhost:8080/check')
-    check(uri)
-  end
-
-  task :production do
-    uri = URI.parse('http://transervicos.herokuapp.com/check')
-    check(uri)
-  end
-end
-
-def check(uri)
-  http = Net::HTTP.new(uri.host, uri.port)
-
-  request = Net::HTTP::Get.new(uri.request_uri)
-  res = http.request(request)
-
-  fail "Application is not ok! Status: #{res.code}" if res.code != '200'
-  puts "Application is ok! Status: #{res.code}"
-  puts JSON.parse(res.body)
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,8 +23,6 @@ module Transervicos
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.version = '1.0.0'
-
     # add custom validators path
     config.autoload_paths += %W("#{config.root}/app/validators/")
   end

--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -1,8 +1,9 @@
 HealthMonitor.configure do |config|
   config.database
+  version = YAML.load_file("#{Rails.configuration.root}/config/version.yml")
 
   config.environmet_variables = {
-    version: Rails.configuration.version,
+    version: version.inject('') { |c, (_k, v)| c + "#{v}." }.chop,
     migration_version: ActiveRecord::Migrator.current_version
   }
 end

--- a/config/version.yml
+++ b/config/version.yml
@@ -1,0 +1,4 @@
+---
+major: 1
+minor: 0
+patch: 0

--- a/lib/tasks/smoketests.rake
+++ b/lib/tasks/smoketests.rake
@@ -1,0 +1,26 @@
+require 'net/https'
+require 'uri'
+require 'json'
+
+namespace :smoketest do
+  task :development do
+    uri = URI.parse('http://localhost:8080/check')
+    check(uri)
+  end
+
+  task :production do
+    uri = URI.parse('http://transervicos.herokuapp.com/check')
+    check(uri)
+  end
+end
+
+def check(uri)
+  http = Net::HTTP.new(uri.host, uri.port)
+
+  request = Net::HTTP::Get.new(uri.request_uri)
+  res = http.request(request)
+
+  fail "Application is not ok! Status: #{res.code}" if res.code != '200'
+  puts "Application is ok! Status: #{res.code}"
+  puts JSON.parse(res.body)
+end

--- a/lib/tasks/version.rake
+++ b/lib/tasks/version.rake
@@ -1,0 +1,38 @@
+require 'yaml'
+
+namespace :version do
+  namespace :up do
+    task :patch do
+      update_version('patch', +1)
+    end
+
+    task :minor do
+      update_version('minor', +1)
+    end
+
+    task :major do
+      update_version('major', +1)
+    end
+  end
+
+  namespace :down do
+    task :patch do
+      update_version('patch', -1)
+    end
+
+    task :minor do
+      update_version('minor', -1)
+    end
+
+    task :major do
+      update_version('major', -1)
+    end
+  end
+end
+
+def update_version(field, version_modifier)
+  file_path = "#{Rails.configuration.root}/config/version.yml"
+  version = YAML.load_file(file_path)
+  version[field] = version[field].to_i + version_modifier
+  File.write(file_path, YAML.dump(version))
+end


### PR DESCRIPTION
Pequenas refatorações nas tasks e adiciona uma melhor maneira de manter a versão da aplicação.

Existe um arquivo `config/version.yml` que contém três entradas `major`, `minor` e `version`. A partir dessas informações será construída a versão atual da aplicação que será exibida na página `/check`.

Existem tasks para aumentar e diminuir esses números, basta fazer `rake version:up:major` para incrementar a versão `major` ou `rake version:down:major` para diminuir. Essas tasks atualizam o arquivo `config/version.yml`.
