### PR TITLE
Corrige problemas na edição de serviços

### DIFF
--- a/app/assets/javascripts/service_form.js
+++ b/app/assets/javascripts/service_form.js
@@ -3,7 +3,6 @@
 
   $(function() {
     var stateSelector = $('#state-selector');
-    var citySelector = $('#city-selector');
 
     var buildOptions = function(collection, valueAttr, textAttr) {
       var options = [];
@@ -15,6 +14,8 @@
 
     var loadCitiesForState = function(){
       var stateId = stateSelector.find("option:selected").val();
+      var citySelector = $('#city-selector');
+
       if (stateId === '') {
         citySelector.attr('disabled', true);
       } else {
@@ -32,23 +33,28 @@
       }
     };
 
-    stateSelector.on('change', loadCitiesForState);
+    var updateOwnerData = function() {
+      if ($('#owner-check input:checked').val() == 'recomendacao') {
+        $('#dados-recomendacao').show();
+        $('#service_owner_name').prop('required',true);
+      }
+      else {
+        $('#dados-recomendacao').hide();
+        $('#service_owner_name').prop('required',false);
+      }
+    }
 
     var ready = function(){
-      $('[name="prestador"]').on('change',function(){
-        if ($(this).val() == 'recomendacao')
-        {
-          $('#dados-recomendacao').show();
-          $('#service_owner_name').prop('required',true);
-        }
-        else
-        {
-          $('#dados-recomendacao').hide();
-          $('#service_owner_name').val('');
-          $('#service_owner_email').val('');
-          $('#service_owner_name').prop('required',false);
-        }
-      });
+      if( $('#owner-check').data('is-owner') == true ) {
+        $('#prestador2').prop('checked', true);
+      } else {
+        $('#prestador1').prop('checked', true);
+      }
+
+      $('[name="prestador"]').on('change', updateOwnerData);
+      stateSelector.on('change', loadCitiesForState);
+
+      updateOwnerData();
       loadCitiesForState();
     };
 

--- a/app/assets/javascripts/service_form.js
+++ b/app/assets/javascripts/service_form.js
@@ -1,0 +1,59 @@
+(function($, window, document) {
+  'use strict';
+
+  $(function() {
+    var stateSelector = $('#state-selector');
+    var citySelector = $('#city-selector');
+
+    var buildOptions = function(collection, valueAttr, textAttr) {
+      var options = [];
+      $.each(collection, function(index, object) {
+        options.push($('<option/>').val(object[valueAttr]).text(object[textAttr]));
+      });
+      return options;
+    };
+
+    var loadCitiesForState = function(){
+      var stateId = stateSelector.find("option:selected").val();
+      if (stateId === '') {
+        citySelector.attr('disabled', true);
+      } else {
+        var url = '/state/' + stateId;
+        $.getJSON(url, function(data) {
+          citySelector.html($('<option/>').text('Selecione uma cidade'));
+          citySelector.append(buildOptions(data['cities'], 'id', 'name'));
+          citySelector.removeAttr('disabled');
+        }).done(function(){
+          var cityId = citySelector.data('selected-city');
+          if (cityId) {
+            citySelector.find('option[value=' + cityId + ']').attr('selected','selected');
+          }
+        });
+      }
+    };
+
+    stateSelector.on('change', loadCitiesForState);
+
+    var ready = function(){
+      $('[name="prestador"]').on('change',function(){
+        if ($(this).val() == 'recomendacao')
+        {
+          $('#dados-recomendacao').show();
+          $('#service_owner_name').prop('required',true);
+        }
+        else
+        {
+          $('#dados-recomendacao').hide();
+          $('#service_owner_name').val('');
+          $('#service_owner_email').val('');
+          $('#service_owner_name').prop('required',false);
+        }
+      });
+      loadCitiesForState();
+    };
+
+    $(document).ready(ready);
+  });
+
+}(window.jQuery, window, document));
+

--- a/app/helpers/services_helper.rb
+++ b/app/helpers/services_helper.rb
@@ -6,4 +6,8 @@ module ServicesHelper
   def states_selector
     State.all.order(:name)
   end
+
+  def should_display_owner_data(service)
+    service.try(:owner_name).present?
+  end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -5,4 +5,7 @@ class Address < ActiveRecord::Base
 
   validates_with CityValidator
   validates_with StateValidator
+
+  accepts_nested_attributes_for :city
+  accepts_nested_attributes_for :state
 end

--- a/app/views/services/_form.html.erb
+++ b/app/views/services/_form.html.erb
@@ -31,10 +31,10 @@
       <%= f.label :other_phone, "Telefone 2" %>
       <%= f.telephone_field :other_phone, placeholder:"", class:"form-control" %>
     </div>
-    <div class="form-group">
+    <div class="form-group" id="owner-check" data-is-owner=<%= should_display_owner_data(@service) %>>
       <div class="radio">
         <label>
-          <input type="radio" name="prestador" id="prestador1" value="prestador" checked>
+          <input type="radio" name="prestador" id="prestador1" value="prestador">
           Sou a pessoa prestadora do serviço.
         </label>
       </div>
@@ -45,7 +45,7 @@
         </label>
       </div>
     </div>
-    <div id="dados-recomendacao" style="display:none">
+    <div id="dados-recomendacao" style="display:none" >
       <div class="form-group input-user">
         <%= f.label :owner_name, "Nome da pessoa prestadora do serviço", class: "label-required" %>
         <%= f.telephone_field :owner_name, placeholder:"Você pode informar o nome social.", class:"form-control" %>

--- a/app/views/services/_form.html.erb
+++ b/app/views/services/_form.html.erb
@@ -45,22 +45,6 @@
         </label>
       </div>
     </div>
-    <script type="text/javascript">
-      $('[name="prestador"]').on('change',function(){
-        if ($(this).val() == 'recomendacao')
-        {
-          $('#dados-recomendacao').show();
-          $('#service_owner_name').prop('required',true);
-        }
-        else
-        {
-          $('#dados-recomendacao').hide();
-          $('#service_owner_name').val('');
-          $('#service_owner_email').val('');
-          $('#service_owner_name').prop('required',false);
-        }
-      });
-    </script>
     <div id="dados-recomendacao" style="display:none">
       <div class="form-group input-user">
         <%= f.label :owner_name, "Nome da pessoa prestadora do serviço", class: "label-required" %>
@@ -79,11 +63,11 @@
     <%= f.fields_for :address do |a| %>
       <div class="form-group">
         <%= f.label :state, "Estado", class: "label-required" %>
-        <%= a.collection_select :state_id, states_selector, :id, :name, {prompt: 'Selecione um estado'}, {id: 'state-selector'} %>
+        <%= a.collection_select :state_id, states_selector, :id, :name, {prompt: 'Selecione um estado'}, {id: 'state-selector' } %>
       </div>
       <div class="form-group">
         <%= f.label :city, "Cidade", class: "label-required" %>
-        <%= a.collection_select :city_id, [], :id, :name, {prompt: 'Selecione uma cidade'}, {id: 'city-selector', disabled: true}%>
+        <%= a.collection_select :city_id, [], :id, :name, {prompt: 'Selecione uma cidade'}, {id: 'city-selector', disabled: true, 'data-selected-city' => @service.try(:address).try(:city_id) }%>
       </div>
       <div class="form-group">
         <%= f.label :street, "Logradouro" %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( service_form.js )

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -23,7 +23,7 @@ describe 'When user enter valid informations', type: :feature do
 end
 
 describe 'When user doesn\'t enter valid informations', type: :feature do
-  let(:user) { build(:user, birth_date: 18.years.ago) }
+  let(:user) { build(:user, birth_date: 17.years.ago) }
 
   scenario 'user doesn\'t fill any name' do
     visit new_user_registration_path

--- a/spec/helpers/services_helper_spec.rb
+++ b/spec/helpers/services_helper_spec.rb
@@ -9,4 +9,16 @@ RSpec.describe ServicesHelper, type: :helper do
     expected_states = [state_a, state_b, state_c]
     expect(states_selector.map(&:name)).to be_eql(expected_states.map(&:name))
   end
+
+  context '#should display owner data' do
+    it 'has data if owner name is present' do
+      service = create(:service, owner_name: 'Jose')
+      expect(should_display_owner_data(service)).to be_truthy
+    end
+
+    it 'does not have data if owner name is not present' do
+      service = create(:service, owner_name: nil)
+      expect(should_display_owner_data(service)).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Foram adicionados scripts para manipular o seletor de cidades, garantindo que quando um usuário já escolheu uma cidade ela é pré-selecionada.

Também foi adicionado um comportamento dinâmico na seleção de quem é o prestador do serviço, garantido que ao editar, os valores serão compatíveis com o que está salvo.

closes #55 
