### PR TITLE
#48 - Removendo seção preview

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -20,35 +20,6 @@
 	</div>
 </header>
 
-<section id="feedback-tw" class="bg-purple">
-	<div class="container">
-		<div class="row">
-			<div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
-				<h2 class="text-center">Olá, TWer!</h2>
-				<p>
-					Para celebrar a Semana da Visibilidade Trans e Travesti, estamos fazendo o
-					pré-lançamento do Transerviços internamente na TW Brasil.
-				</p>
-				<p>
-					O objetivo é apresentar nosso 1º MVP e contar com a ajuda de todos para
-					coletar feedbacks e registros de possíveis erros até <strong>sexta, 29/01</strong>,
-					antes do lançamento oficial.
-				</p>
-				<p>
-					Compartilhe seu feedback mandando um email para
-					<a href="mailto:tuxavier@thoughtworks.com?subject=Transerviços - Feedback">tuxavier@thoughtworks.com</a>
-					com o assunto "Transerviços - Feedback".
-				</p>
-				<p>
-					Ah, e se quiser fazer parte do nosso querido time de voluntários,
-					ficaremos muito felizes com sua ajuda para continuarmos o projeto
-					<i class="fa fa-heart text-fuchsia"></i> <span class="sr-only">(coração agradecido)</span>
-				</p>
-			</div>
-		</div>
-	</div>
-</section>
-
 <section id="trans-hoje">
 	<a name="trans-hoje"></a>
 	<div class="container">


### PR DESCRIPTION
Pull Request que remove a seção de preview da home page do site Transerviços conforme solicitado na issue #48 .

Ver imagem abaixo:

<img width="1280" alt="screen shot 2016-03-02 at 20 58 48" src="https://cloud.githubusercontent.com/assets/1073869/13479993/9d4832fc-e0b9-11e5-965a-a19eb9d2d56b.png">
